### PR TITLE
[stages] integrated harmonic oscillator firmware

### DIFF
--- a/stages/chain_state.cc
+++ b/stages/chain_state.cc
@@ -159,9 +159,9 @@ void ChainState::ReceiveRight() {
       request_.request = REQUEST_NONE;
 //    } else if (rx_index == 0xf) {
     } else if (rx_index == 0x7) {
-      // NOTE: I'm pretty sure the above change to the if-statement correctly
+      // TODO: I'm pretty sure the above change to the if-statement correctly
       // solves for the updates to how index extraction works, but not 100%
-      // positive.
+      // positive, verify.
 
       // This suspiciously looks like a state change request packet!
       // We will take care of it later.
@@ -312,7 +312,7 @@ void ChainState::Configure(
                 !channel_state_[channel].configuration().harmosc;
             ++channel;
             ++num_channels;
-            add_more_segments &= channel < last_channel
+            add_more_segments &= channel < last_channel;
           }
           if (dirty || num_channels != oscillator[i].num_channels()) {
             oscillator[i].Configure(num_channels, harmosc_waveshapes);
@@ -337,7 +337,7 @@ void ChainState::Configure(
       harmosc_fundamental = -1.0f;
       
       // Create a normal channel, trying to extend it as far as possible.
-      size_t num_segments = 0;
+      int num_segments = 0;
       bool add_more_segments = true;
       bool dirty = false;
       
@@ -418,6 +418,8 @@ inline void ChainState::UpdateLocalState(
         break;
       case HARMOSC_STATUS_END:
         tx_harmosc_fundamental_ = -1.0f;
+        break;
+      default:
         break;
     }
   }
@@ -713,8 +715,6 @@ void ChainState::HandleRequest(Settings* settings) {
       uint8_t new_loop_bit = loop_bit;
       if ((channel >= request_.argument[0] && channel < request_.argument[3])) {
         new_loop_bit = 0x0;
-        // NOTE: everything in the range is cancelled by default, and only becomes a
-        // new loop if it meets the later checks
       }
       if (channel == request_.argument[1] || channel == request_.argument[2]) {
         if (request_.argument[1] == request_.argument[2]) {

--- a/stages/chain_state.h
+++ b/stages/chain_state.h
@@ -32,13 +32,12 @@
 #include "stmlib/stmlib.h"
 
 #include "stages/io_buffer.h"
-#include "stages/segment_generator.h"
 #include "stages/oscillator.h"
+#include "stages/segment_generator.h"
+#include "stages/shared_constants.h"
 
 namespace stages {
 
-const size_t kMaxChainSize = 6;
-const size_t kMaxNumChannels = kMaxChainSize * kNumChannels;
 const size_t kPacketSize = 24;
 
 class SerialLink;
@@ -174,9 +173,9 @@ class ChainState {
   struct LeftToRightPacket {
     uint8_t last_patched_channel;  // 1 byte
     int8_t segment;  // 1 byte
+    Loop last_loop;  // 2 bytes
     float phase;  // 4 bytes
     float harmosc_fundamental;  // 4 bytes
-    Loop last_loop;  // 2 bytes
     ChannelBitmask switch_pressed[kMaxChainSize];  // 6 bytes
     ChannelBitmask input_patched[kMaxChainSize];  // 6 bytes
   };

--- a/stages/io_buffer.h
+++ b/stages/io_buffer.h
@@ -32,13 +32,14 @@
 #include "stmlib/stmlib.h"
 #include "stmlib/utils/gate_flags.h"
 
+#include "stages/shared_constants.h"
+
 #include <algorithm>
 
 namespace stages {
 
 const size_t kNumBlocks = 2;
 const size_t kBlockSize = 8;
-const size_t kNumChannels = 6;
 
 class IOBuffer {
  public:

--- a/stages/makeflash.sh
+++ b/stages/makeflash.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Adapted for mac from https://github.com/joeSeggiola/eurorack/blob/stages-multi/stages/makeflash.sh
+
+# This script builds Stages on the vagrant development machine, creating 
+# the WAV file if desired and plays it.
+# Usage:
+#   ./makeflash.sh [clean] [size] [wav]
+
+# Build command
+COMMAND=""
+if [[ $* == *clean* ]]; then
+    COMMAND="$COMMAND make -f stages/makefile clean &&"
+fi
+COMMAND="$COMMAND make -f stages/makefile"
+if [[ $* == *size* ]]; then
+    COMMAND="$COMMAND && make -f stages/makefile size"
+fi
+if [[ $* == *wav* ]]; then
+    COMMAND="$COMMAND && make -f stages/makefile wav"
+fi
+
+# Show command
+echo
+echo "EXECUTING:"
+echo "  $COMMAND"
+echo
+
+# Run command on the vagrant development machine
+# https://github.com/mklement0/n-install/issues/1#issuecomment-159089258
+vagrant ssh -c "set -i; . ~/.bashrc; set +i; $COMMAND"
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+# Play the WAV file on the default ALSA device
+if [[ $* == *wav* ]]; then
+    WAVFILE="`pwd`/../build/stages/stages.wav"
+    echo
+    echo "PLAYING:"
+    echo "  `ls -l "$WAVFILE"`"
+    echo
+    afplay $WAVFILE
+fi
+
+echo
+
+exit 0

--- a/stages/oscillator.cc
+++ b/stages/oscillator.cc
@@ -1,0 +1,197 @@
+// Copyright 2017 Emilie Gillet.
+//
+// Author: Emilie Gillet (emilie.o.gillet@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// See http://creativecommons.org/licenses/MIT/ for more information.
+//
+// -----------------------------------------------------------------------------
+//
+// Harmonic oscillator.
+
+#include "stages/oscillator.h"
+
+namespace stages {
+
+using namespace std;
+
+void Oscillator::Render(float* out, size_t size) {
+  std::fill(&out[0], &out[size], 0.0f);
+
+  for (uint8_t channel_index = 0; channel_index < num_channels_; ++channel_index) {
+    float this_channel[size];
+    RenderSingleHarmonic(channel_index, &this_channel[0], size);
+    ParameterInterpolator am(
+        &previous_amplitude_[channel_index],
+        amplitude_[channel_index] * amplitude_[channel_index],
+        size);
+
+    for (uint8_t i = 0; i < size; ++i) {
+      out[i] += this_channel[i] * am.Next() * gain();
+    }
+  }
+}
+
+void Oscillator::RenderSingleHarmonic(
+    uint8_t channel_index,
+    float* out,
+    size_t size) {
+  switch (waveshape_[channel_index]) {
+    case 0:
+      RenderSingleHarmonicWaveshape(channel_index, 0.5f, OSCILLATOR_SHAPE_SINE, out, size);
+      break;
+    case 1:
+      RenderSingleHarmonicWaveshape(channel_index, 0.5f, OSCILLATOR_SHAPE_TRIANGLE, out, size);
+      break;
+    case 2:
+    case 3:
+      RenderSingleHarmonicWaveshape(channel_index, 0.5f, OSCILLATOR_SHAPE_SQUARE, out, size);
+      break;
+    case 4:
+      RenderSingleHarmonicWaveshape(channel_index, 0.5f, OSCILLATOR_SHAPE_SAW, out, size);
+      break;
+    case 5:
+      RenderSingleHarmonicWaveshape(channel_index, 0.75f, OSCILLATOR_SHAPE_SQUARE, out, size);
+      break;
+    case 6:
+    case 7:
+      RenderSingleHarmonicWaveshape(channel_index, 0.9f, OSCILLATOR_SHAPE_SQUARE, out, size);
+      break;
+  }
+}
+
+void Oscillator::RenderSingleHarmonicWaveshape(
+    uint8_t channel_index,
+    float pw,
+    OscillatorShape shape,
+    float* out,
+    size_t size) {
+  float frequency = fundamental_ * ratio_[channel_index];
+  CONSTRAIN(frequency, kMinFrequency, kMaxFrequency);
+  CONSTRAIN(pw, fabsf(frequency) * 2.0f, 1.0f - 2.0f * fabsf(frequency))
+
+  stmlib::ParameterInterpolator fm(&frequency_[channel_index], frequency, size);
+  stmlib::ParameterInterpolator pwm(&pw_[channel_index], pw, size);
+
+  float next_sample = next_sample_[channel_index];
+
+  while (size--) {
+    float this_sample = next_sample;
+    next_sample = 0.0f;
+
+    float frequency = fm.Next();
+    float pw = (shape == OSCILLATOR_SHAPE_SQUARE_TRIANGLE ||
+                shape == OSCILLATOR_SHAPE_TRIANGLE) ? 0.5f : pwm.Next();
+    phase_[channel_index] += frequency;
+
+    if (shape <= OSCILLATOR_SHAPE_SAW) {
+      if (phase_[channel_index] >= 1.0f) {
+        phase_[channel_index] -= 1.0f;
+        float t = phase_[channel_index] / frequency;
+        this_sample -= ThisBlepSample(t);
+        next_sample -= NextBlepSample(t);
+      }
+      next_sample += phase_[channel_index];
+
+      if (shape == OSCILLATOR_SHAPE_SAW) {
+        *out++ = 2.0f * this_sample - 1.0f;
+      } else {
+        lp_state_[channel_index] += 0.25f *
+            ((hp_state_[channel_index] - this_sample) - lp_state_[channel_index]);
+        *out++ = 4.0f * lp_state_[channel_index];
+        hp_state_[channel_index] = this_sample;
+      }
+    } else if (shape == OSCILLATOR_SHAPE_SINE) {
+      if (phase_[channel_index] >= 1.0f) {
+        phase_[channel_index] -= 1.0f;
+      }
+      next_sample = stmlib::Interpolate(lut_sine, phase_[channel_index], 1024.0f);
+      *out++ = this_sample;
+    } else if (shape <= OSCILLATOR_SHAPE_SLOPE) {
+      float slope_up = 2.0f;
+      float slope_down = 2.0f;
+      if (shape == OSCILLATOR_SHAPE_SLOPE) {
+        slope_up = 1.0f / (pw);
+        slope_down = 1.0f / (1.0f - pw);
+      }
+      if (high_[channel_index] ^ (phase_[channel_index] < pw)) {
+        float t = (phase_[channel_index] - pw) / frequency;
+        float discontinuity = (slope_up + slope_down) * frequency;
+        this_sample -= ThisIntegratedBlepSample(t) * discontinuity;
+        next_sample -= NextIntegratedBlepSample(t) * discontinuity;
+        high_[channel_index] = phase_[channel_index] < pw;
+      }
+      if (phase_[channel_index] >= 1.0f) {
+        phase_[channel_index] -= 1.0f;
+        float t = phase_[channel_index] / frequency;
+        float discontinuity = (slope_up + slope_down) * frequency;
+        this_sample += ThisIntegratedBlepSample(t) * discontinuity;
+        next_sample += NextIntegratedBlepSample(t) * discontinuity;
+        high_[channel_index] = true;
+      }
+      next_sample += high_[channel_index]
+        ? phase_[channel_index] * slope_up
+        : 1.0f - (phase_[channel_index] - pw) * slope_down;
+      *out++ = 2.0f * this_sample - 1.0f;
+    } else {
+      if (high_[channel_index] ^ (phase_[channel_index] >= pw)) {
+        float t = (phase_[channel_index] - pw) / frequency;
+        float discontinuity = 1.0f;
+        this_sample += ThisBlepSample(t) * discontinuity;
+        next_sample += NextBlepSample(t) * discontinuity;
+        high_[channel_index] = phase_[channel_index] >= pw;
+      }
+      if (phase_[channel_index] >= 1.0f) {
+        phase_[channel_index] -= 1.0f;
+        float t = phase_[channel_index] / frequency;
+        this_sample -= ThisBlepSample(t);
+        next_sample -= NextBlepSample(t);
+        high_[channel_index] = false;
+      }
+      next_sample += phase_[channel_index] < pw ? 0.0f : 1.0f;
+
+      if (shape == OSCILLATOR_SHAPE_SQUARE_TRIANGLE) {
+        const float integrator_coefficient = frequency * 0.0625f;
+        this_sample = 128.0f * (this_sample - 0.5f);
+        lp_state_[channel_index] += integrator_coefficient *
+            (this_sample - lp_state_[channel_index]);
+        *out++ = lp_state_[channel_index];
+      } else if (shape == OSCILLATOR_SHAPE_SQUARE_DARK) {
+        const float integrator_coefficient = frequency * 2.0f;
+        this_sample = 4.0f * (this_sample - 0.5f);
+        lp_state_[channel_index] += integrator_coefficient *
+            (this_sample - lp_state_[channel_index]);
+        *out++ = lp_state_[channel_index];
+      } else if (shape == OSCILLATOR_SHAPE_SQUARE_BRIGHT) {
+        const float integrator_coefficient = frequency * 2.0f;
+        this_sample = 2.0f * this_sample - 1.0f;
+        lp_state_[channel_index] += integrator_coefficient *
+            (this_sample - lp_state_[channel_index]);
+        *out++ = (this_sample - lp_state_[channel_index]) * 0.5f;
+      } else {
+        this_sample = 2.0f * this_sample - 1.0f;
+        *out++ = this_sample;
+      }
+    }
+  }
+  next_sample_[channel_index] = next_sample;
+}
+
+}  // namespace stages

--- a/stages/oscillator.h
+++ b/stages/oscillator.h
@@ -29,6 +29,7 @@
 #ifndef STAGES_OSCILLATOR_H_
 #define STAGES_OSCILLATOR_H_
 
+#include <algorithm>
 #include <cmath>
 
 #include "stmlib/dsp/dsp.h"
@@ -37,8 +38,12 @@
 #include "stmlib/utils/random.h"
 
 #include "stages/resources.h"
+#include "stages/shared_constants.h"
 
 namespace stages {
+
+using namespace std;
+using namespace stmlib;
 
 enum OscillatorShape {
   OSCILLATOR_SHAPE_IMPULSE_TRAIN,
@@ -52,12 +57,11 @@ enum OscillatorShape {
   OSCILLATOR_SHAPE_SQUARE_TRIANGLE,
 };
 
-const float kSampleRate = 31250.0f;
 const float kMiddleCHz = 261.6255f;
 const float kMaxFrequency = 0.25f;
 const float kMinFrequency = 0.00001f;
-float kScalingGainBasis = 0.66f;
-float kScalingCoefficient = 0.78758f;
+const float kScalingGainBasis = 0.66f;
+const float kScalingCoefficient = 0.78758f;
 
 // TODO - experiment with these, originals below
 //float ouroboros_ratios[] = {

--- a/stages/segment_generator.cc
+++ b/stages/segment_generator.cc
@@ -406,6 +406,7 @@ void SegmentGenerator::ProcessZero(
 void SegmentGenerator::ProcessSlave(
     const GateFlags* gate_flags, SegmentGenerator::Output* out, size_t size) {
   while (size--) {
+    // NOTE: the values for active_segment_ seem inverted but :shrug:
     active_segment_ = out->segment == monitored_segment_ ? 0 : 1;
     out->value = active_segment_ ? 0.0f : 1.0f - out->phase;
     ++out;

--- a/stages/segment_generator.h
+++ b/stages/segment_generator.h
@@ -64,6 +64,7 @@ enum Type {
 struct Configuration {
   Type type;
   bool loop;
+  bool harmosc;
 };
 
 struct Parameters {

--- a/stages/segment_generator.h
+++ b/stages/segment_generator.h
@@ -34,12 +34,10 @@
 #include "stmlib/utils/gate_flags.h"
 
 #include "stages/delay_line_16_bits.h"
-
 #include "stages/ramp_extractor.h"
+#include "stages/shared_constants.h"
 
 namespace stages {
-
-const float kSampleRate = 31250.0f;
 
 // Each segment generator can handle up to 36 segments. That's a bit of a waste
 // of RAM because the 6 generators running on a module will never have to deal

--- a/stages/settings.h
+++ b/stages/settings.h
@@ -52,7 +52,7 @@ struct ChannelCalibrationData {
 struct PersistentData {
   ChannelCalibrationData channel_calibration_data[kNumChannels];
   uint8_t padding[16];
-  
+
   enum { tag = 0x494C4143 };  // CALI
 };
 

--- a/stages/shared_constants.h
+++ b/stages/shared_constants.h
@@ -1,0 +1,42 @@
+// Copyright 2017 Emilie Gillet.
+//
+// Author: Emilie Gillet (emilie.o.gillet@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// See http://creativecommons.org/licenses/MIT/ for more information.
+//
+// -----------------------------------------------------------------------------
+//
+// Shared constants.
+
+#ifndef STAGES_SHARED_CONSTANTS_H_
+#define STAGES_SHARED_CONSTANTS_H_
+
+namespace stages {
+
+const float kSampleRate = 31250.0f;
+
+const size_t kNumChannels = 6;
+const size_t kMaxChainSize = 6;
+const size_t kMaxNumChannels = kMaxChainSize * kNumChannels;
+
+}  // namespace stages
+
+#endif  // STAGES_SHARED_CONSTANTS_H_

--- a/stages/stages.cc
+++ b/stages/stages.cc
@@ -24,20 +24,20 @@
 
 #include <stm32f37x_conf.h>
 
-#include "chain_state.h"
-#include "cv_reader.h"
-#include "drivers/dac.h"
-#include "drivers/gate_inputs.h"
-#include "drivers/serial_link.h"
-#include "drivers/system.h"
-#include "factory_test.h"
-#include "io_buffer.h"
-#include "oscillator.h"
-#include "segment_generator.h"
-#include "settings.h"
 #include "stmlib/dsp/dsp.h"
 #include "stmlib/dsp/units.h"
-#include "ui.h"
+#include "stages/chain_state.h"
+#include "stages/cv_reader.h"
+#include "stages/drivers/dac.h"
+#include "stages/drivers/gate_inputs.h"
+#include "stages/drivers/serial_link.h"
+#include "stages/drivers/system.h"
+#include "stages/factory_test.h"
+#include "stages/io_buffer.h"
+#include "stages/oscillator.h"
+#include "stages/segment_generator.h"
+#include "stages/settings.h"
+#include "stages/ui.h"
 
 using namespace stages;
 using namespace std;
@@ -101,9 +101,6 @@ SegmentGenerator::Output out[kBlockSize];
 float harmosc_out[kBlockSize];
 
 void Process(IOBuffer::Block* block, size_t size) {
-  // NOTE: I don't think we need to pass an out equivalent for oscillator, since
-  // that is just used for passing segment/phase info from R->L, which there is
-  // no need for in the case of the oscillator.
   chain_state.Update(
       *block,
       &settings,


### PR DESCRIPTION
The new firmware works just like the regular firmware except you can create harmonic oscillator blocks alongside regular segment generators, without having to switch to ouroboros mode.

These blocks work almost identically to the harmonic oscillators in ouroboros mode, except they can be of variable length (minimum two segments and no maximum, including spanning multiple modules) and function alongside the module’s regular segment generation functionality, instead of having either/or. This means a single Stages module can be used as up to 3 independent harmonic oscillators, and a chain of Stages modules could function as a one giant harmonic oscillator with up to 36 independent components.

In terms of interacting with the module very little has changed. Constructing a harmonic oscillator block is very similar to setting up a multi-segment loop - you do it by simply pressing the buttons for the beginning and the end of the harmonic oscillator block at the same time. Here’s the difference: in the regular firmware, if you attempt to create a multi-segment loop prior to the first patched gate input, the module simply won’t allow it. In this firmware, doing so will create a new harmonic oscillator block. Note this means harmonic oscillator blocks can only be set up in ranges to the left of the first patched gate input. This also means one feature of the original ouroboros mode had to be sacrificed: the use of the gate inputs as triggers for fixed-length exponential decay envelopes is no longer possible, you’ll have to provide your own envelopes if you want to recreate this behavior.

There are some other differences in terms of setting up harmonic oscillator blocks versus multi-segment loops that are worth calling out. One is that you can have multiple harmonic oscillator blocks prior to the first patched gate input. This differs from how loops work inside segment ranges, where if you create a new looping segment (or multi-segment loop), it will cancel any other loops in that segment range (between two patched gate inputs). There is also a difference in how harmonic oscillator blocks are cancelled. Multi-segment loops can be cancelled by long-pressing either the beginning or the end button of the range. For harmonic oscillator blocks, long-pressing either the start or end button of the block will only have the effect of changing the wave shape of that segment (same as the original ouroboros mode). Instead you cancel the range by pressing both the start and end buttons for that range simultaneously, exactly the same interaction as creating the range initially. New harmonic oscillator blocks cannot be defined to overlap existing ones, any attempt to do so will simply be ignored. The only other way to cancel a harmonic oscillator block is to patch a gate input anywhere in the range or to the left of it.