### PR TITLE
[plaits] frequency locking with aux crossfade

### DIFF
--- a/plaits/dsp/voice.cc
+++ b/plaits/dsp/voice.cc
@@ -197,6 +197,14 @@ void Voice::Render(
 
   bool already_enveloped = pp_s.already_enveloped;
   e->Render(p, out_buffer_, aux_buffer_, size, &already_enveloped);
+
+  // Crossfade the aux output between main and aux models.
+  float out_proportion = 1.0f - patch.aux_crossfade;
+  float aux_proportion = patch.aux_crossfade;
+
+  for (size_t i = 0; i < kMaxBlockSize; ++i) {
+    aux_buffer_[i] = (aux_buffer_[i] * aux_proportion) + (out_buffer_[i] * out_proportion);
+  }
   
   bool lpg_bypass = already_enveloped || \
       (!modulations.level_patched && !modulations.trigger_patched);

--- a/plaits/dsp/voice.h
+++ b/plaits/dsp/voice.h
@@ -127,6 +127,7 @@ struct Patch {
   int engine;
   float decay;
   float lpg_colour;
+  float aux_crossfade;
 };
 
 struct Modulations {

--- a/plaits/makeflash.sh
+++ b/plaits/makeflash.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Adapted for mac from https://github.com/joeSeggiola/eurorack/blob/stages-multi/stages/makeflash.sh
+
+# This script builds Plaits on the vagrant development machine, creating 
+# the WAV file if desired and plays it.
+# Usage:
+#   ./makeflash.sh [clean] [size] [wav]
+
+# Build command
+COMMAND=""
+if [[ $* == *clean* ]]; then
+    COMMAND="$COMMAND make -f plaits/makefile clean &&"
+fi
+COMMAND="$COMMAND make -f plaits/makefile"
+if [[ $* == *size* ]]; then
+    COMMAND="$COMMAND && make -f plaits/makefile size"
+fi
+if [[ $* == *wav* ]]; then
+    COMMAND="$COMMAND && make -f plaits/makefile wav"
+fi
+
+# Show command
+echo
+echo "EXECUTING:"
+echo "  $COMMAND"
+echo
+
+# Run command on the vagrant development machine
+# https://github.com/mklement0/n-install/issues/1#issuecomment-159089258
+vagrant ssh -c "set -i; . ~/.bashrc; set +i; $COMMAND"
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+# Play the WAV file on the default ALSA device
+if [[ $* == *wav* ]]; then
+    WAVFILE="`pwd`/../build/plaits/plaits.wav"
+    echo
+    echo "PLAYING:"
+    echo "  `ls -l "$WAVFILE"`"
+    echo
+    afplay $WAVFILE
+fi
+
+echo
+
+exit 0

--- a/plaits/plaits.cc
+++ b/plaits/plaits.cc
@@ -116,6 +116,7 @@ void Init() {
   
   BufferAllocator allocator(shared_buffer, 16384);
   voice.Init(&allocator);
+  patch.aux_crossfade = 1.0f;
   
   volatile size_t counter = 1000000;
   while (counter--);

--- a/plaits/plaits.cc
+++ b/plaits/plaits.cc
@@ -116,7 +116,6 @@ void Init() {
   
   BufferAllocator allocator(shared_buffer, 16384);
   voice.Init(&allocator);
-  patch.aux_crossfade = 1.0f;
   
   volatile size_t counter = 1000000;
   while (counter--);

--- a/plaits/pot_controller.h
+++ b/plaits/pot_controller.h
@@ -74,8 +74,12 @@ class PotController {
     offset_ = offset;
   }
   
+  inline bool locked() {
+    return state_ == POT_STATE_LOCKING || state_ == POT_STATE_HIDDEN_PARAMETER;
+  }
+
   inline void Lock() {
-    if (state_ == POT_STATE_LOCKING || state_ == POT_STATE_HIDDEN_PARAMETER) {
+    if (locked()) {
       return;
     }
     if (hidden_parameter_) {
@@ -84,6 +88,14 @@ class PotController {
     }
   }
   
+  inline void ToggleLock() {
+    if (locked()) {
+      Unlock();
+    } else {
+      Lock();
+    }
+  }
+
   inline bool editing_hidden_parameter() const {
     return state_ == POT_STATE_HIDDEN_PARAMETER;
   }

--- a/plaits/pot_controller.h
+++ b/plaits/pot_controller.h
@@ -100,6 +100,15 @@ class PotController {
     return state_ == POT_STATE_HIDDEN_PARAMETER;
   }
   
+  inline void LockMainParameter(float main_parameter) {
+    Lock();
+    *main_parameter_ = main_parameter;
+  }
+
+  inline float main_parameter() {
+    return *main_parameter_;
+  }
+
   inline void Unlock() {
     if (state_ == POT_STATE_HIDDEN_PARAMETER || was_catching_up_) {
       state_ = POT_STATE_CATCHING_UP;

--- a/plaits/settings.cc
+++ b/plaits/settings.cc
@@ -75,6 +75,8 @@ bool Settings::Init() {
   state_.decay = 128;
   state_.octave = 255;
   state_.color_blind = 0;
+  state_.aux_crossfade = 1.0f;
+  state_.frequency_pot_main_parameter = 1000.0f;
   
   bool success = chunk_storage_.Init(&persistent_data_, &state_);
   

--- a/plaits/settings.h
+++ b/plaits/settings.h
@@ -57,7 +57,9 @@ struct State {
   uint8_t decay;
   uint8_t octave;
   uint8_t color_blind;
-  uint8_t padding[3];
+  uint8_t aux_crossfade;
+  float frequency_pot_main_parameter;
+  uint8_t padding[6];
   enum { tag = 0x54415453 };  // STAT
 };
 

--- a/plaits/ui.cc
+++ b/plaits/ui.cc
@@ -69,7 +69,7 @@ void Ui::Init(Patch* patch, Modulations* modulations, Settings* settings) {
   
   // Bind pots to parameters.
   pots_[POTS_ADC_CHANNEL_FREQ_POT].Init(
-      &transposition_, NULL, 2.0f, -1.0f);
+      &transposition_, &patch->aux_crossfade, 2.0f, -1.0f);
   pots_[POTS_ADC_CHANNEL_HARMONICS_POT].Init(
       &patch->harmonics, &octave_, 1.0f, 0.0f);
   pots_[POTS_ADC_CHANNEL_TIMBRE_POT].Init(
@@ -117,6 +117,7 @@ void Ui::SaveState() {
   state->lpg_colour = static_cast<uint8_t>(patch_->lpg_colour * 256.0f);
   state->decay = static_cast<uint8_t>(patch_->decay * 256.0f);
   state->octave = static_cast<uint8_t>(octave_ * 256.0f);
+
   settings_->SaveState();
 }
 
@@ -261,12 +262,15 @@ void Ui::ReadSwitches() {
           mode_ = UI_MODE_DISPLAY_OCTAVE;
         }
         
-        // Long, double press: enter calibration mode.
+        // Long, double press: lock coarse frequency.
         if (press_time_[0] >= kLongPressTime &&
             press_time_[1] >= kLongPressTime) {
           press_time_[0] = press_time_[1] = 0;
+          ignore_release_[0] = true;
+          ignore_release_[1] = true;
+
           RealignPots();
-          StartCalibration();
+          pots_[POTS_ADC_CHANNEL_FREQ_POT].ToggleLock();
         }
         
         // Long press or actually editing any hidden parameter: display value


### PR DESCRIPTION
Frequency locking for Plaits in the style of Frap Tools Brenso. To lock or unlock coarse frequency, you long-press (2+ seconds) both buttons at once. The FM attenuverter continues to work as a fine frequency control when the FM input is unpatched, and the V/Oct and FM inputs continue to work as normal when patched.

This gesture replaces the calibration procedure, so if the module needs to be recalibrated for any reason after installing this alt firmware, you'll need to revert to the stock firmware first. This can also be seen as a benefit, as you're less likely to accidentally end up recalibrating the module.

In addition to making it harder to accidentally detune the oscillator, this frequency locking frees up the frequency knob for other purposes. When frequency is locked a hidden parameter is now exposed, controlled manually by the frequency knob, for crossfading between the main and aux synthesis models (full-CCW for the main model, full-CW for the aux model). This crossfaded output will be present at the aux output while the main output continues to output only the main synthesis model as in the stock firmware. This replaces the need for an external mixer/crossfader in order to use both models at once, though it is not under voltage control - for voltage controlled crossfading you'll still need to use an external module or two.

If you'd like to use the aux crossfading without the frequency locking, you can simply switch into frequency locked mode, adjust the crossfade, and then switch back out; the aux crossfade setting you've chosen will be maintained.

Frequency locks and aux crossfade settings are preserved across power cycles.