### PR TITLE
elements with frequency locking

### DIFF
--- a/elements/cv_scaler.h
+++ b/elements/cv_scaler.h
@@ -43,7 +43,9 @@ struct CalibrationSettings {
   float offset[CV_ADC_CHANNEL_LAST];
   uint8_t boot_in_easter_egg_mode;
   uint8_t resonator_model;
-  uint8_t padding[62];
+  uint8_t frequency_locked;
+  float locked_pot_note;
+  uint8_t padding[57];
 };
 
 class Patch;
@@ -122,6 +124,7 @@ class CvScaler {
   }
   
   void SaveCalibration();
+  void ToggleFrequencyLock();
   
   inline bool gate() const { return gate_; }
   inline uint8_t pot_value(size_t index) const {
@@ -148,6 +151,21 @@ class CvScaler {
     calibration_settings_.resonator_model = resonator_model;
   }
   
+  // ranges from (0 to 60) + 19 + (-2 to 2)
+  // = (17 to 81)
+  inline float pot_note() const {
+    return pot_quantized_[POT_RESONATOR_COARSE] + 19.0f +
+        (pot_lp_[POT_RESONATOR_FINE] * (2.0f / 3.3f));
+  }
+
+  inline float pot_value_scaled_unipolar(size_t index) {
+    return static_cast<float>(pots_.value(index)) / 65536.0f;
+  }
+
+  inline float pot_value_scaled_bipolar(size_t index) {
+    return static_cast<float>(pots_.value(index)) / 32768.0f - 1.0f;
+  }
+
   inline bool freshly_baked() const {
     return freshly_baked_;
   }

--- a/elements/makeflash.sh
+++ b/elements/makeflash.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Adapted for mac from https://github.com/joeSeggiola/eurorack/blob/stages-multi/stages/makeflash.sh
+
+# This script builds Elements on the vagrant development machine, creating
+# the WAV file if desired and plays it.
+# Usage:
+#   ./makeflash.sh [clean] [size] [wav]
+
+# Build command
+COMMAND=""
+if [[ $* == *clean* ]]; then
+    COMMAND="$COMMAND make -f elements/makefile clean &&"
+fi
+COMMAND="$COMMAND make -f elements/makefile"
+if [[ $* == *size* ]]; then
+    COMMAND="$COMMAND && make -f elements/makefile size"
+fi
+if [[ $* == *wav* ]]; then
+    COMMAND="$COMMAND && make -f elements/makefile wav"
+fi
+
+# Show command
+echo
+echo "EXECUTING:"
+echo "  $COMMAND"
+echo
+
+# Run command on the vagrant development machine
+# https://github.com/mklement0/n-install/issues/1#issuecomment-159089258
+vagrant ssh -c "set -i; . ~/.bashrc; set +i; $COMMAND"
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+# Play the WAV file on the default ALSA device
+if [[ $* == *wav* ]]; then
+    WAVFILE="`pwd`/../build/elements/elements.wav"
+    echo
+    echo "PLAYING:"
+    echo "  `ls -l "$WAVFILE"`"
+    echo
+    afplay $WAVFILE
+fi
+
+echo
+
+exit 0

--- a/elements/ui.cc
+++ b/elements/ui.cc
@@ -148,7 +148,7 @@ void Ui::OnSwitchPressed(const Event& e) {
       break;
     
     case 1:
-      mode_ = UI_MODE_CALIBRATION_1;
+      cv_scaler_->ToggleFrequencyLock();
       break;
     
     case 2:


### PR DESCRIPTION
Giving Elements the old frequency locking treatment. Once again the UI interaction for toggling frequency locking replaces the calibration procedure, meaning in this case moving all the attenuverters to full-CCW and then long-pressing (3+ seconds) the button.

Both coarse and fine frequency are "locked", however compared with Plaits or Rings there is more flexibility to transpose after locking because we have two knobs available. The coarse frequency knob becomes an octave switch (with 7 steps from -3 octaves to +3 octaves) and the fine frequency knob becomes a semitone transposer (with 15 steps from -7 semitones to +7 semitones). In this way accidental detuning is made more difficult and recalling a precise tuning is always as easy as moving both knobs to noon, but you can also still easily mess with scales and intervals.