### PR TITLE
aux crossfade with cv

### DIFF
--- a/plaits/dsp/voice.h
+++ b/plaits/dsp/voice.h
@@ -69,6 +69,8 @@ const int kTriggerDelay = 5;
 const bool kAuxCrossfade = true;
 const bool kOctaveSwitch = false;
 
+const bool kUseModelCVForAuxCrossfade = true;
+
 class ChannelPostProcessor {
  public:
   ChannelPostProcessor() { }


### PR DESCRIPTION
Adds CV control of the crossfade between main and aux models, replacing CV control of the engine via the Model input.