### PR TITLE
support aux crossfade cv without knob control

### DIFF
--- a/plaits/dsp/voice.cc
+++ b/plaits/dsp/voice.cc
@@ -214,8 +214,11 @@ void Voice::Render(
   e->Render(p, out_buffer_, aux_buffer_, size, &already_enveloped);
 
   // Crossfade the aux output between main and aux models.
-  if (kAuxCrossfade) {
-    float aux_proportion = patch.freqlock_param;
+  if (kAuxCrossfade || kUseModelCVForAuxCrossfade) {
+    float aux_proportion = 0.5f;
+    if (kAuxCrossfade) {
+      aux_proportion = patch.freqlock_param;
+    }
     if (kUseModelCVForAuxCrossfade) {
       aux_proportion += modulations.engine * 0.5f;
     }

--- a/plaits/dsp/voice.h
+++ b/plaits/dsp/voice.h
@@ -66,8 +66,8 @@ const int kTriggerDelay = 5;
 // At most one of these should be enabled, they are the
 // different options for what to do with a locked
 // frequency knob.
-const bool kAuxCrossfade = true;
-const bool kOctaveSwitch = false;
+const bool kAuxCrossfade = false;
+const bool kOctaveSwitch = true;
 
 const bool kUseModelCVForAuxCrossfade = true;
 const bool kUseLevelCVForDecay = false;


### PR DESCRIPTION
support aux crossfade cv without knob control so the knob can be used for octave shift while aux crossfading is still controlled by cv on the MODEL input.