### PR TITLE
fm cv input option

### DIFF
--- a/rings/cv_scaler.cc
+++ b/rings/cv_scaler.cc
@@ -151,6 +151,7 @@ void CvScaler::Read(Patch* patch, PerformanceState* performance_state, Settings*
   performance_state->chord_table = static_cast<ChordTable>(settings->ChordTableOption());
   performance_state->waveform_exciter = settings->WaveformExciterOption();
   performance_state->strum_hold_option = settings->StrumHoldOption();
+  performance_state->fm_input_option = settings->FMInputOption();
 
   // Process all CVs / pots.
   for (size_t i = 0; i < ADC_CHANNEL_LAST; ++i) {

--- a/rings/dsp/performance_state.h
+++ b/rings/dsp/performance_state.h
@@ -68,9 +68,14 @@ struct PerformanceState {
   uint8_t frequency_locked;
   uint8_t waveform_exciter;
   uint8_t strum_hold_option;
+  uint8_t fm_input_option;
 
   bool MiniElements() const {
     return (mode == MODE_MINI_ELEMENTS_STEREO) || (mode == MODE_MINI_ELEMENTS_EXCITER);
+  }
+
+  bool FMInputRepurposed() const {
+    return MiniElements() && (fm_input_option == 1);
   }
 };
 

--- a/rings/settings.cc
+++ b/rings/settings.cc
@@ -36,6 +36,7 @@ const uint8_t kNumModeOptions = 5;
 const uint8_t kNumWaveformExciterOptions = 3;
 const uint8_t kNumChordTableOptions = 3;
 const uint8_t kNumStrumHoldOptions = 2;
+const uint8_t kNumFMInputOptions = 2;
 
 stmlib::Storage<1> storage;
 
@@ -75,6 +76,7 @@ void Settings::InitState() {
   data_.state.waveform_exciter_option = 0;
   data_.state.chord_table_option = 0;
   data_.state.strum_hold_option = 0;
+  data_.state.fm_input_option = 0;
 }
 
 void Settings::SwitchModeOption() {
@@ -96,6 +98,11 @@ void Settings::SwitchChordTableOption() {
 void Settings::SwitchStrumHoldOption() {
   uint8_t new_option = (StrumHoldOption() + 1) % kNumStrumHoldOptions;
   mutable_state()->strum_hold_option = new_option;
+}
+
+void Settings::SwitchFMInputOption() {
+  uint8_t new_option = (FMInputOption() + 1) % kNumFMInputOptions;
+  mutable_state()->fm_input_option = new_option;
 }
 
 void Settings::Save() {

--- a/rings/settings.h
+++ b/rings/settings.h
@@ -35,7 +35,7 @@
 
 namespace rings {
 
-const uint32_t kSettingsId = 414344649;
+const uint32_t kSettingsId = 259583919;
 
 struct CalibrationData {
   float pitch_offset;
@@ -57,12 +57,13 @@ struct State {
   uint8_t waveform_exciter_option;
   uint8_t chord_table_option;
   uint8_t strum_hold_option;
+  uint8_t fm_input_option;
 };
 
 struct SettingsData {
   CalibrationData calibration_data; // 40 bytes
-  State state;  // 13 bytes
-  uint8_t padding[11];
+  State state;  // 14 bytes
+  uint8_t padding[10];
 };
 
 class Settings {
@@ -100,6 +101,11 @@ class Settings {
   void SwitchStrumHoldOption();
   inline uint8_t StrumHoldOption() {
     return data_.state.strum_hold_option;
+  }
+
+  void SwitchFMInputOption();
+  inline uint8_t FMInputOption() {
+    return data_.state.fm_input_option;
   }
 
   inline State* mutable_state() {

--- a/rings/ui.cc
+++ b/rings/ui.cc
@@ -41,7 +41,7 @@ namespace rings {
 const int32_t kAnimationDuration = 1200;
 const int32_t kLongPressDuration = 2800;
 const int32_t kMediumPressDuration = 200;
-const uint8_t kNumOptions = 4;
+const uint8_t kNumOptions = 5;
 
 using namespace std;
 using namespace stmlib;
@@ -227,6 +227,9 @@ void Ui::Poll() {
         } else if (option_menu_item_ == 3) {
           leds_.set(0, 0, slow_blink);
           option_value = settings_->ChordTableOption();
+        } else if (option_menu_item_ == 4) {
+          leds_.set(0, slow_blink, 0);
+          option_value = settings_->FMInputOption();
         }
 
         bool menu_indicator = (system_clock.milliseconds() % 10000) > 9000;
@@ -418,6 +421,8 @@ void Ui::OnSwitchReleased(const Event& e) {
           settings_->SwitchStrumHoldOption();
         } else if (option_menu_item_ == 3) {
           settings_->SwitchChordTableOption();
+        } else if (option_menu_item_ == 4) {
+          settings_->SwitchFMInputOption();
         }
         break;
       default:


### PR DESCRIPTION
make an option to repurpose the FM cv input to control exciter timbre in mini-elements modes