### PR TITLE
set internal sample rate to 44.1k

### DIFF
--- a/plaits/dsp/dsp.h
+++ b/plaits/dsp/dsp.h
@@ -33,7 +33,7 @@
 
 namespace plaits {
   
-static const float kSampleRate = 48000.0f;
+static const float kSampleRate = 44100.0f;
 
 // There is no proper PLL for I2S, only a divider on the system clock to derive
 // the bit clock.
@@ -43,8 +43,12 @@ static const float kSampleRate = 48000.0f;
 // Frame clock = Bit clock / 32 = 47872.34 Hz
 //
 // That's only 4.6 cts of error, but we care!
+//
+// Adjusted to 44.1K ->
+// 47872.34 * (44100 / 48000) = 43982.71
 
-static const float kCorrectedSampleRate = 47872.34f;
+// static const float kCorrectedSampleRate = 47872.34f;
+static const float kCorrectedSampleRate = 43982.71f;
 const float a0 = (440.0f / 8.0f) / kCorrectedSampleRate;
 
 const size_t kMaxBlockSize = 24;

--- a/plaits/dsp/fx/diffuser.h
+++ b/plaits/dsp/fx/diffuser.h
@@ -31,6 +31,7 @@
 
 #include "stmlib/stmlib.h"
 
+#include "plaits/dsp/dsp.h"
 #include "plaits/dsp/fx/fx_engine.h"
 
 namespace plaits {
@@ -42,7 +43,7 @@ class Diffuser {
   
   void Init(uint16_t* buffer) {
     engine_.Init(buffer);
-    engine_.SetLFOFrequency(LFO_1, 0.3f / 48000.0f);
+    engine_.SetLFOFrequency(LFO_1, 0.3f / kSampleRate);
     lp_decay_ = 0.0f;
   }
   

--- a/plaits/plaits.cc
+++ b/plaits/plaits.cc
@@ -136,7 +136,7 @@ void Init() {
   settings.Init();
   ui.Init(&patch, &modulations, &settings);
   
-  audio_dac.Init(48000, kBlockSize);
+  audio_dac.Init(44100, kBlockSize);
 
   audio_dac.Start(&FillBuffer);
   IWDG_Enable();

--- a/plaits_roved/dsp/dsp.h
+++ b/plaits_roved/dsp/dsp.h
@@ -33,7 +33,7 @@
 
 namespace plaits {
   
-static const float kSampleRate = 48000.0f;
+static const float kSampleRate = 44100.0f;
 
 // There is no proper PLL for I2S, only a divider on the system clock to derive
 // the bit clock.
@@ -43,8 +43,12 @@ static const float kSampleRate = 48000.0f;
 // Frame clock = Bit clock / 32 = 47872.34 Hz
 //
 // That's only 4.6 cts of error, but we care!
+//
+// Adjusted to 44.1K ->
+// 47872.34 * (44100 / 48000) = 43982.71
 
-static const float kCorrectedSampleRate = 47872.34f;
+// static const float kCorrectedSampleRate = 47872.34f;
+static const float kCorrectedSampleRate = 43982.71f;
 const float a0 = (440.0f / 8.0f) / kCorrectedSampleRate;
 
 const size_t kMaxBlockSize = 24;

--- a/plaits_roved/dsp/fx/diffuser.h
+++ b/plaits_roved/dsp/fx/diffuser.h
@@ -31,6 +31,7 @@
 
 #include "stmlib/stmlib.h"
 
+#include "plaits/dsp/dsp.h"
 #include "plaits/dsp/fx/fx_engine.h"
 
 namespace plaits {
@@ -42,7 +43,7 @@ class Diffuser {
   
   void Init(uint16_t* buffer) {
     engine_.Init(buffer);
-    engine_.SetLFOFrequency(LFO_1, 0.3f / 48000.0f);
+    engine_.SetLFOFrequency(LFO_1, 0.3f / kSampleRate);
     lp_decay_ = 0.0f;
   }
   

--- a/plaits_roved/plaits.cc
+++ b/plaits_roved/plaits.cc
@@ -136,7 +136,7 @@ void Init() {
   settings.Init();
   ui.Init(&patch, &modulations, &settings);
   
-  audio_dac.Init(48000, kBlockSize);
+  audio_dac.Init(44100, kBlockSize);
 
   audio_dac.Start(&FillBuffer);
   IWDG_Enable();


### PR DESCRIPTION
for performance reasons, this resolves the CPU overload problems in some of the red modes