### PR TITLE
fine tuning for frequency locked modes + cs70 style octave/fifth switching + variable octave switch slew

### DIFF
--- a/plaits/dsp/voice.h
+++ b/plaits/dsp/voice.h
@@ -140,6 +140,7 @@ struct Patch {
   // 0 - manual octave switching
   // 1 - manual control of decay (without button press)
   // 2 - manual aux crossfade
+  // 3 - manual octave/fifth switching (CS70 style)
   uint8_t locked_frequency_pot_option;
   // 0 - cv control of model (original)
   // 1 - cv control of lpg colour

--- a/plaits/settings.cc
+++ b/plaits/settings.cc
@@ -43,7 +43,7 @@ bool Settings::Init() {
   bool success = chunk_storage_.Init(&persistent_data_, &state_);
   
   CONSTRAIN(state_.engine, 0, 23);
-  CONSTRAIN(state_.locked_frequency_pot_option, 0, 2);
+  CONSTRAIN(state_.locked_frequency_pot_option, 0, 3);
   CONSTRAIN(state_.model_cv_option, 0, 2);
   CONSTRAIN(state_.level_cv_option, 0, 1);
   CONSTRAIN(state_.aux_subosc_wave_option, 0, 2);
@@ -111,6 +111,8 @@ void Settings::InitState() {
 
   // alt firmware other
   state_.locked_octave = 4;
+  state_.extra_fine_tune = 0;
+  state_.internal_octave_slew = 0;
 }
 
 void Settings::SavePersistentData() {

--- a/plaits/settings.h
+++ b/plaits/settings.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 // See http://creativecommons.org/licenses/MIT/ for more information.
 //
 // -----------------------------------------------------------------------------
@@ -35,7 +35,7 @@
 #include "plaits/drivers/cv_adc.h"
 
 namespace plaits {
-  
+
 struct ChannelCalibrationData {
   float offset;
   float scale;
@@ -58,6 +58,7 @@ struct State {
   uint8_t decay;
   uint8_t octave;
   uint8_t fine_tune;
+  uint8_t extra_fine_tune;
 
   // alt firmware options
   uint8_t locked_frequency_pot_option;
@@ -72,7 +73,7 @@ struct State {
   // alt firmware other
   uint8_t locked_octave;
 
-  uint8_t padding[2];
+  uint8_t padding[1];
 
   enum { tag = 0x54415453 };  // STAT
 };
@@ -81,18 +82,18 @@ class Settings {
  public:
   Settings() { }
   ~Settings() { }
-  
+
   bool Init();
   void InitPersistentData();
   void InitState();
 
   void SavePersistentData();
   void SaveState();
-  
+
   inline const ChannelCalibrationData& calibration_data(int channel) const {
     return persistent_data_.channel_calibration_data[channel];
   }
-  
+
   inline ChannelCalibrationData* mutable_calibration_data(int channel) {
     return &persistent_data_.channel_calibration_data[channel];
   }
@@ -104,17 +105,17 @@ class Settings {
   inline State* mutable_state() {
     return &state_;
   }
-  
+
  private:
   PersistentData persistent_data_;
   State state_;
-  
+
   stmlib::ChunkStorage<
       0x08004000,
       0x08007000,
       PersistentData,
       State> chunk_storage_;
-  
+
   DISALLOW_COPY_AND_ASSIGN(Settings);
 };
 

--- a/plaits/settings.h
+++ b/plaits/settings.h
@@ -58,7 +58,6 @@ struct State {
   uint8_t decay;
   uint8_t octave;
   uint8_t fine_tune;
-  uint8_t extra_fine_tune;
 
   // alt firmware options
   uint8_t locked_frequency_pot_option;
@@ -72,8 +71,10 @@ struct State {
 
   // alt firmware other
   uint8_t locked_octave;
+  uint8_t extra_fine_tune;
+  uint8_t internal_octave_slew;
 
-  uint8_t padding[1];
+  // uint8_t padding[0];
 
   enum { tag = 0x54415453 };  // STAT
 };

--- a/plaits/ui.h
+++ b/plaits/ui.h
@@ -125,6 +125,7 @@ class Ui {
   float data_transfer_progress_;
   float fine_tune_;
   float extra_fine_tune_;
+  float internal_octave_slew_;
   float transposition_;
   float octave_;
   Patch* patch_;
@@ -132,6 +133,7 @@ class Ui {
   NormalizationProbe normalization_probe_;
   PotController pots_[POTS_ADC_CHANNEL_LAST];
   float pitch_lp_;
+  float octave_slew_;
 
   Settings* settings_;
 

--- a/plaits/ui.h
+++ b/plaits/ui.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 // See http://creativecommons.org/licenses/MIT/ for more information.
 //
 // -----------------------------------------------------------------------------
@@ -71,15 +71,15 @@ class Ui {
  public:
   Ui() { }
   ~Ui() { }
-  
+
   void Init(Patch* patch, Modulations* modulations, Settings* settings);
-  
+
   void Poll();
-  
+
   void set_active_engine(int active_engine) {
     active_engine_ = active_engine;
   }
-  
+
   void DisplayDataTransferProgress(float progress) {
     mode_ = UI_MODE_DISPLAY_DATA_TRANSFER_PROGRESS;
     data_transfer_progress_ = progress;
@@ -87,13 +87,13 @@ class Ui {
     // an error.
     pwm_counter_ = progress == 1.0f || progress < 0.0f ? 1500 : 0;
   }
-  
+
   inline bool test_mode() const {
     return mode_ == UI_MODE_TEST;
   }
 
   uint8_t HandleFactoryTestingRequest(uint8_t command);
-  
+
  private:
   void UpdateLEDs();
   void ReadSwitches();
@@ -111,19 +111,20 @@ class Ui {
       pots_[i].Realign();
     }
   }
-  
+
   UiMode mode_;
-  
+
   CvAdc cv_adc_;
   PotsAdc pots_adc_;
   Leds leds_;
   Switches switches_;
-  
+
   int ui_task_;
   int option_index_;
-  
+
   float data_transfer_progress_;
   float fine_tune_;
+  float extra_fine_tune_;
   float transposition_;
   float octave_;
   Patch* patch_;
@@ -131,9 +132,9 @@ class Ui {
   NormalizationProbe normalization_probe_;
   PotController pots_[POTS_ADC_CHANNEL_LAST];
   float pitch_lp_;
-  
+
   Settings* settings_;
-  
+
   int normalization_detection_count_;
   int normalization_detection_mismatches_[kNumNormalizedChannels];
   uint32_t normalization_probe_state_;
@@ -141,7 +142,7 @@ class Ui {
   int pwm_counter_;
   int press_time_[SWITCH_LAST];
   bool ignore_release_[SWITCH_LAST];
-  
+
   int active_engine_;
   bool enable_alt_navigation_;
 
@@ -150,11 +151,11 @@ class Ui {
   // but using manual aux crossfade, stores the last octave
   // chosen by manually selection using the frequency pot
   uint8_t locked_octave_;
-    
+
   stmlib::HysteresisQuantizer2 octave_quantizer_;
-  
+
   static const CvAdcChannel normalized_channels_[kNumNormalizedChannels];
-    
+
   DISALLOW_COPY_AND_ASSIGN(Ui);
 };
 


### PR DESCRIPTION
Some new features

1. Allows a second level of fine tuning while in the octave switching view, using the FM attenuverter
2. A new setting for the locked frequency knob allowing CS70 style jumps between fifths and octaves (https://www.youtube.com/watch?v=LD8krBROiqk)
3. Continuing with the CS70 theme, adding an (optional) variable slew for octave jumps (whether in the regular octaves mode or the CS70 mode)